### PR TITLE
🌟 New: Adds .gitignore file filtering out .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Simple PR that adds a `.gitignore` file preventing `.DS_Store` metadata files from OS X from being version controlled.
