### PR TITLE
🌟 New: Adds .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a `.editorconfig` file to help enforce consistency with indentation across examples. 

I've kept it pretty basic and reflective of the majority of examples I've looked at, which seem to be 4-space indentation. 
## graphics-examples users

To use this — install a plugin for your editor!
- [Sublime Text](https://github.com/sindresorhus/editorconfig-sublime)
- [Atom](https://github.com/sindresorhus/atom-editorconfig)

More info: [editorconfig.org](http://editorconfig.org/)
