### PR TITLE
Fix stacked bar

### DIFF
--- a/column-stacked/changes.txt
+++ b/column-stacked/changes.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/column-stacked/changes.txt
+++ b/column-stacked/changes.txt
@@ -1,1 +1,0 @@
-Hello world

--- a/column-stacked/index.html
+++ b/column-stacked/index.html
@@ -28,7 +28,7 @@
         var yAxisHighlight//=10;
         var labels=false;//show numbers on bars
         var numTicksy = 5;//rough number of ticks for y axis
-        var sort="ascending"//specify 'ascending', 'descending', 'alpha' or 'none'
+        var sort="none"//specify 'ascending', 'descending', 'alpha' or 'none'
 
         //Use the frames array to set unique values for each media type of frame
         // Print column sizes-- 1col 53.71mm: 2col 112.25mm: 3col 170.8mm: 4col 229.34mm: 5col 287.88mm: 6col 346.43


### PR DESCRIPTION
Changed default sort order to ‘none’ - so order of data in cvs will be preserved